### PR TITLE
fix: Matrix not detecting login attempt as JSON

### DIFF
--- a/src/main/java/com/pseudosmp/tools/bridge/Matrix.java
+++ b/src/main/java/com/pseudosmp/tools/bridge/Matrix.java
@@ -308,7 +308,7 @@ public class Matrix {
 		if (addBearer && !access_token.isEmpty())
 			con.setRequestProperty("Authorization", "Bearer " + access_token);
 
-		con.setRequestProperty("Content-Type", "application/json; utf-8");
+		con.setRequestProperty("Content-Type", "application/json");
 		con.setRequestProperty("Accept", "application/json");
 		con.setDoOutput(true);
 


### PR DESCRIPTION
Matrix returns error code 400 `M_NOT_JSON` due to unsupported content type header.

- Changed Content-Type from `application/json; utf-8` to simply `application/json`

Solution has been tested using Postman, as well as the error.